### PR TITLE
fix(stems): match the drive filename and the deck's decode grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Sidecars are named with the truncation Rekordbox applies when it exports a
+  track to a drive, keeping the first 44 characters of the stem. A track whose
+  library filename is longer reached the drive shortened while its sidecar kept
+  the full name, and the deck never matched the two. Two tracks that collide
+  only once truncated are now reported as ambiguous, as they always should have
+  been.
+- Stems for mp3 and AAC sources are aligned to the deck's decoder rather than
+  FFmpeg's. Those containers declare the samples their encoder prepended;
+  FFmpeg drops them and the deck plays them, which left the stem 25 ms early and
+  the vocal fully audible in the instrumental while the vocal pad still worked.
+  Existing sidecars for such sources have to be generated again — delete them,
+  or the run keeps them as already generated. WAV, AIFF and FLAC sources were
+  never affected.
+
+The manifest gained `encoderDelayFrames`, the padding each stem was pushed back
+by.
+
 ## 0.3.0
 
 First tagged release. Git history was reset to a single commit at this point, so

--- a/tests/test_stem_studio.py
+++ b/tests/test_stem_studio.py
@@ -16,7 +16,9 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from tools.rx3_stems import provisioning, separation, sidecar
 from tools.rx3_stems import job as job_module
 from tools.rx3_stems.job import JobState, StemJob, failure_detail
-from tools.rx3_stems.rekordbox import file_url_to_path, parse_collection, safe_stem
+from tools.rx3_stems.rekordbox import (
+    EXPORT_STEM_LIMIT, export_stem, file_url_to_path, parse_collection, safe_stem,
+)
 
 
 def write_export(root: pathlib.Path, tracks: list[tuple[str, str, str, pathlib.Path]]) -> pathlib.Path:
@@ -98,6 +100,17 @@ class RekordboxTests(unittest.TestCase):
         self.assertEqual(safe_stem("A/B:C\x01 "), "A_B_C")
         self.assertEqual(safe_stem("   "), "track")
 
+    def test_export_stem_reproduces_the_drive_truncation(self):
+        # A name Rekordbox shortens on export, cut where the deck cuts it,
+        # trailing space included.
+        long_name = "Air Force Blanche - Gims, Jul (Extended Mix By Fuvi Clan)"
+        self.assertEqual(export_stem(long_name), "Air Force Blanche - Gims, Jul (Extended Mix ")
+        self.assertEqual(len(export_stem(long_name)), EXPORT_STEM_LIMIT)
+        # A name already within the limit is exported as it stands.
+        self.assertEqual(export_stem("B.M.S (by my side) - Rambo goyard"),
+                         "B.M.S (by my side) - Rambo goyard")
+        self.assertEqual(export_stem("   "), "track")
+
 
 class JobTests(unittest.TestCase):
     def runtime(self) -> provisioning.Runtime:
@@ -119,6 +132,49 @@ class JobTests(unittest.TestCase):
             self.assertEqual(state.results[0].status, "existing")
             self.assertEqual(state.errors, ())
             self.assertTrue((output / "rx3-stems-manifest.json").is_file())
+
+    def test_the_sidecar_carries_the_name_the_drive_export_gives_the_track(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            audio = root / "Air Force Blanche - Gims, Jul (Extended Mix By Fuvi Clan).aiff"
+            audio.write_bytes(b"fixture")
+            xml = write_export(root, [("1", "Air Force Blanche", "Gims", audio)])
+            collection = parse_collection(xml)
+            output = root / "export"
+            stems = output / "RX3_STEMS"
+            stems.mkdir(parents=True)
+            # Named as the deck will ask for it, not as the library holds it.
+            existing = stems / "Air Force Blanche - Gims, Jul (Extended Mix .rx3stem"
+            existing.write_bytes(b"x" * 128)
+
+            state = StemJob(self.runtime(), collection, collection.playlists[0], output).run()
+            self.assertEqual(state.errors, ())
+            self.assertEqual(state.results[0].status, "existing")
+            self.assertEqual(state.results[0].sidecar, existing.name)
+
+    def test_two_sources_that_collide_only_once_truncated_are_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            sources = []
+            for folder, suffix in (("one", "first mix"), ("two", "second mix")):
+                source = root / folder / f"A Very Long Title That Rekordbox Will Cut - {suffix}.aiff"
+                source.parent.mkdir()
+                source.write_bytes(b"fixture")
+                sources.append(source)
+            self.assertEqual(export_stem(sources[0].stem), export_stem(sources[1].stem))
+            xml = write_export(root, [
+                ("1", "One", "A", sources[0]),
+                ("2", "Two", "B", sources[1]),
+            ])
+            collection = parse_collection(xml)
+            output = root / "export"
+            (output / "RX3_STEMS").mkdir(parents=True)
+            (output / f"RX3_STEMS/{export_stem(sources[0].stem)}.rx3stem").write_bytes(b"x" * 128)
+
+            state = StemJob(self.runtime(), collection, collection.playlists[0], output).run()
+            self.assertEqual(len(state.results), 1)
+            self.assertEqual(len(state.errors), 1)
+            self.assertIn("Ambiguous filename", state.errors[0].error)
 
     def test_refuses_two_distinct_sources_with_the_same_basename(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -445,6 +501,110 @@ class SidecarGainTests(unittest.TestCase):
             )
         for architecture in ("Demucs", "VR", None, "future"):
             self.assertIsNone(separation.input_normalization(settings, architecture))
+
+
+class SidecarAlignmentTests(unittest.TestCase):
+    """The deck indexes the sidecar by the position of its own decoder, which
+    plays the encoder padding that ffmpeg drops on the way into the separator."""
+
+    RATE = 44100
+    SECONDS = 3
+
+    def decode(self, path, *, untrimmed):
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error",
+             *(sidecar.UNTRIMMED if untrimmed else ()), "-i", str(path),
+             "-map", "0:a:0", "-vn", "-ar", str(self.RATE), "-ac", "2",
+             "-f", "s16le", "-"],
+            check=True, capture_output=True,
+        )
+        return result.stdout
+
+    def fixture(self, root):
+        """A padded mp3, and the stem a separator returns for it.
+
+        The separator sees ffmpeg's trimmed decode, so handing that decode back
+        as the stem makes any residue against the mix pure misalignment.
+        """
+        raw = root / "tone.s16le"
+        with raw.open("wb") as destination:
+            for index in range(self.RATE * self.SECONDS):
+                value = int(12000 * math.sin(2 * math.pi * 220 * index / self.RATE))
+                destination.write(struct.pack("<hh", value, value))
+        source = root / "source.mp3"
+        subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-f", "s16le",
+             "-ar", str(self.RATE), "-ac", "2", "-i", str(raw), "-c:a", "libmp3lame",
+             "-b:a", "320k", str(source)],
+            check=True,
+        )
+        stem = root / "vocal.wav"
+        subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-i", str(source),
+             "-map", "0:a:0", "-vn", "-ar", str(self.RATE), "-ac", "2", str(stem)],
+            check=True,
+        )
+        return source, stem
+
+    @unittest.skipUnless(shutil.which("ffmpeg"), "ffmpeg is required")
+    def test_the_encoder_padding_of_a_lossy_source_is_put_back(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            source, stem = self.fixture(root)
+            mix = self.decode(source, untrimmed=True)
+            self.assertGreater(
+                len(mix), len(self.decode(source, untrimmed=False)),
+                "the fixture has to declare padding to be meaningful",
+            )
+
+            output = root / "aligned.rx3stem"
+            result = sidecar.write_sidecar(stem, output, match_full=source)
+
+            self.assertTrue(result.aligned)
+            self.assertGreater(result.delay, 0)
+            self.assertEqual(result.frames, len(mix) // 4)
+            # The stem is the mix here, so anything left over is offset. The
+            # padding itself is silent in the stem: the separator never saw it,
+            # and 25 ms of encoder ramp-in is not part of the vocal.
+            payload = output.read_bytes()[sidecar.HEADER.size:]
+            worst = max(
+                abs(struct.unpack_from("<h", payload, offset)[0]
+                    - struct.unpack_from("<h", mix, offset)[0])
+                for offset in range(result.delay * 4, len(payload), 2)
+            )
+            # The tone moves about 376 counts per frame, so a single frame of
+            # offset would show here as two orders of magnitude more than the
+            # codec's own round-trip noise.
+            self.assertLess(worst, 100, "the stem does not sit on the deck's grid")
+
+    @unittest.skipUnless(shutil.which("ffmpeg"), "ffmpeg is required")
+    def test_a_source_without_padding_keeps_the_grid_it_already_had(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            raw = root / "tone.s16le"
+            raw.write_bytes(struct.pack("<hh", 4000, 4000) * (self.RATE // 2))
+            source = root / "source.wav"
+            subprocess.run(
+                ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-f", "s16le",
+                 "-ar", str(self.RATE), "-ac", "2", "-i", str(raw), str(source)],
+                check=True,
+            )
+            result = sidecar.write_sidecar(source, root / "out.rx3stem", match_full=source)
+            self.assertEqual(result.delay, 0)
+            self.assertTrue(result.aligned)
+            self.assertEqual(result.frames, self.RATE // 2)
+
+    def test_an_unmeasurable_offset_leaves_the_stem_where_the_separator_put_it(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            trimmed, untrimmed = root / "trimmed", root / "untrimmed"
+            # Silence matches at every offset, so no probe is ever unique.
+            trimmed.write_bytes(b"\0" * 4 * sidecar.SAMPLE_RATE)
+            untrimmed.write_bytes(b"\0" * 4 * (sidecar.SAMPLE_RATE + 512))
+            self.assertIsNone(sidecar._encoder_delay(trimmed, untrimmed))
+            # Identical lengths mean nothing was dropped, whatever the content.
+            untrimmed.write_bytes(b"\0" * 4 * sidecar.SAMPLE_RATE)
+            self.assertEqual(sidecar._encoder_delay(trimmed, untrimmed), 0)
 
 
 class ModelFileTests(unittest.TestCase):

--- a/tools/rx3_stems/job.py
+++ b/tools/rx3_stems/job.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field, replace
 from typing import Callable
 
 from tools.rx3_stems.provisioning import Acceleration, Runtime, resolve_acceleration
-from tools.rx3_stems.rekordbox import Collection, Playlist, Track, safe_stem
+from tools.rx3_stems.rekordbox import Collection, Playlist, Track, export_stem
 from tools.rx3_stems.separation import VOCAL_STEM, Settings, input_normalization
 from tools.rx3_stems.sidecar import write_sidecar
 
@@ -66,6 +66,8 @@ class TrackResult:
     # the samples the s16 container could not hold once it was applied.
     gain: float = 1.0
     clipped: int = 0
+    # Encoder padding the stem was pushed back by to land on the deck's grid.
+    delay: int = 0
 
     def as_manifest_entry(self) -> dict[str, object]:
         return {
@@ -73,6 +75,7 @@ class TrackResult:
             "sourceFile": self.source_file, "sidecar": self.sidecar,
             "bytes": self.size, "status": self.status,
             "gainCorrection": round(self.gain, 6), "clippedSamples": self.clipped,
+            "encoderDelayFrames": self.delay,
         }
 
 
@@ -258,17 +261,19 @@ class StemJob:
         source = track.location
         if not source.is_file():
             raise FileNotFoundError("Source file not found")
-        base = safe_stem(source.stem)
+        # The name the track carries on the exported drive, which is the only
+        # name the deck ever asks for.
+        base = export_stem(source.stem)
         collision = used_names.get(base.casefold())
         if collision is not None and collision != source:
             raise ValueError(
-                f"Ambiguous filename with {collision.name}: the RX3 load interface "
-                "cannot distinguish these two paths"
+                f"Ambiguous filename with {collision.name}: both are exported as "
+                f"{base}, and the RX3 load interface cannot distinguish them"
             )
         used_names[base.casefold()] = source
 
         destination = output / f"{base}{SIDECAR_SUFFIX}"
-        gain, clipped = 1.0, 0
+        gain, clipped, delay = 1.0, 0, 0
         if destination.is_file() and destination.stat().st_size > MINIMUM_SIDECAR_BYTES:
             self._update(stage="Already generated", track_progress=100)
             status = "existing"
@@ -291,7 +296,15 @@ class StemJob:
                             self.settings, self.architecture
                         ),
                     )
-                    gain, clipped = encoded.gain, encoded.clipped
+                    gain, clipped, delay = encoded.gain, encoded.clipped, encoded.delay
+                    if not encoded.aligned:
+                        self._notice(
+                            f"{destination.name}: the encoder padding of "
+                            f"{source.name} could not be measured, so the stem "
+                            "stays on the separator's timeline. If the deck "
+                            "leaves vocal in the instrumental, convert the "
+                            "source to WAV or FLAC and generate it again."
+                        )
                     if clipped:
                         self._notice(
                             f"{destination.name}: {clipped} sample(s) exceeded full "
@@ -308,7 +321,7 @@ class StemJob:
             track_id=track.track_id, artist=track.artist, title=track.title,
             source_file=source.name, sidecar=destination.name,
             size=destination.stat().st_size, status=status,
-            gain=gain, clipped=clipped,
+            gain=gain, clipped=clipped, delay=delay,
         )
 
     def run(self) -> JobState:

--- a/tools/rx3_stems/rekordbox.py
+++ b/tools/rx3_stems/rekordbox.py
@@ -12,6 +12,12 @@ from dataclasses import dataclass, field
 
 
 DRIVE_LETTER = re.compile(r"^/[A-Za-z]:")
+# Exporting to a drive shortens the filename: Rekordbox keeps the first 44
+# characters of the stem and the extension, and leaves the library file alone.
+# The deck asks for the sidecar under the basename of the file it loaded, which
+# is the shortened one, so the sidecar has to carry the same cut. Trailing
+# spaces survive the cut on the device, so nothing is trimmed after it.
+EXPORT_STEM_LIMIT = 44
 
 
 @dataclass(frozen=True)
@@ -78,6 +84,15 @@ def safe_stem(value: str) -> str:
     value = unicodedata.normalize("NFC", value).replace("/", "_").replace(":", "_")
     value = "".join(character for character in value if ord(character) >= 32).strip(" .")
     return value[:180] or "track"
+
+
+def export_stem(value: str) -> str:
+    """The stem this file carries once Rekordbox has exported it to a drive.
+
+    A stem already within the limit is returned unchanged, so a drive filled by
+    hand rather than by an export matches just the same.
+    """
+    return safe_stem(value)[:EXPORT_STEM_LIMIT] or "track"
 
 
 def parse_collection(xml_path: pathlib.Path) -> Collection:

--- a/tools/rx3_stems/sidecar.py
+++ b/tools/rx3_stems/sidecar.py
@@ -26,6 +26,22 @@ MEASURE = "aformat=sample_fmts=fltp,astats=reset=0"
 # Each line carries an ffmpeg `[Parsed_astats_N @ ...]` prefix, so no anchor.
 PEAK_LEVEL = re.compile(r"Peak level dB:\s*(-?\d+(?:\.\d+)?|-?inf)")
 CLIPPED_SAMPLES = re.compile(r"Number of clipped samples:\s*(\d+)")
+# An mp3 or AAC file declares the samples its encoder prepended, and ffmpeg
+# drops them. The deck does not: `PcmReader` position zero is the first sample
+# its own decoder emits, padding included. A stem cut on ffmpeg's grid
+# therefore sits ahead of the mix the deck plays, and 25 ms of offset is enough
+# for the subtraction to leave the whole vocal audible while the vocal alone
+# still sounds correct. `skip_manual` hands the decoder's output over untouched,
+# which is the grid every frame index here is expressed in.
+UNTRIMMED = ("-flags2", "+skip_manual")
+# No encoder prepends anything close to a second; a larger apparent offset is a
+# measurement gone wrong rather than padding.
+MAX_ENCODER_DELAY = SAMPLE_RATE
+# Long enough that the pattern cannot repeat by chance, short enough to read.
+PROBE_FRAMES = 4096
+# Positions in the trimmed decode to take that pattern from. Silence matches
+# everywhere, so a probe that is not unique is abandoned for the next one.
+PROBE_POSITIONS = (0.5, 0.25, 0.75, 0.1)
 
 
 @dataclass(frozen=True)
@@ -38,6 +54,11 @@ class SidecarResult:
     gain: float = 1.0
     # Samples the container could not hold once that factor was applied.
     clipped: int = 0
+    # Encoder padding the stem was pushed back by to sit on the deck's grid.
+    delay: int = 0
+    # False when that padding could not be measured and the stem was left on
+    # the separator's own grid, which is only correct for a source without any.
+    aligned: bool = True
 
 
 def _decode(
@@ -72,6 +93,40 @@ def _peak_amplitude(report: str) -> float | None:
     return 0.0 if loudest == -math.inf else 10.0 ** (loudest / 20.0)
 
 
+def _encoder_delay(trimmed: pathlib.Path, untrimmed: pathlib.Path) -> int | None:
+    """Frames ffmpeg dropped from the head of `trimmed`, or None if unreadable.
+
+    Both files hold the same decoder output, one with the declared padding
+    removed and one without, so the offset is found by locating a stretch of the
+    trimmed decode inside the untrimmed one rather than by trusting a timestamp.
+    The first frames differ either way, which is why the pattern is taken from
+    further in.
+    """
+    trimmed_frames = trimmed.stat().st_size // 4
+    extra = untrimmed.stat().st_size // 4 - trimmed_frames
+    if extra == 0:
+        return 0
+    if extra < 0:
+        return None
+    limit = min(extra, MAX_ENCODER_DELAY)
+    with trimmed.open("rb") as source, untrimmed.open("rb") as reference:
+        for fraction in PROBE_POSITIONS:
+            position = int(trimmed_frames * fraction)
+            if position + PROBE_FRAMES > trimmed_frames:
+                continue
+            source.seek(position * 4)
+            probe = source.read(PROBE_FRAMES * 4)
+            reference.seek(position * 4)
+            window = reference.read((limit + PROBE_FRAMES) * 4)
+            offset = window.find(probe)
+            # An offset off the frame grid, or a pattern that repeats, means the
+            # match says nothing; silence is the usual reason for both.
+            if offset < 0 or offset % 4 or window.find(probe, offset + 4) >= 0:
+                continue
+            return offset // 4
+    return None
+
+
 def write_sidecar(
     vocals: pathlib.Path,
     output: pathlib.Path,
@@ -83,8 +138,10 @@ def write_sidecar(
 ) -> SidecarResult:
     """Convert `vocals` to the RX3 audio domain and write the sidecar container.
 
-    `match_full` aligns the frame count to the full track decoded at 44.1 kHz
-    rather than trusting the separator output duration.
+    `match_full` aligns the stem to the full track as the deck's own decoder
+    emits it, rather than trusting the separator output duration: the frame
+    count comes from that decode, and any encoder padding ffmpeg dropped on the
+    way into the separator is put back at the head of the stem.
 
     `separator_normalization` is the peak the separator scaled the mix to before
     inference, when its architecture does that. The stem it returns then carries
@@ -101,20 +158,50 @@ def write_sidecar(
         workspace = pathlib.Path(directory)
         target_frames: int | None = None
         gain = 1.0
+        delay = 0
+        aligned = True
         if match_full is not None:
-            full_raw = workspace / "full.s16le"
-            # Measured after the resample, which is where librosa measures it,
-            # and before the s16 conversion, which would clamp the overshoot.
-            measured = _decode(ffmpeg, [
-                "-i", str(match_full), "-map", "0:a:0", "-vn",
-                "-af", f"aresample={SAMPLE_RATE},{MEASURE}",
-                "-ar", str(SAMPLE_RATE), "-ac", str(CHANNELS),
-                "-f", "s16le", str(full_raw),
-            ], report=True)
-            full_size = full_raw.stat().st_size
-            if not full_size or full_size % 4:
-                raise ValueError("full track decodes to empty or unaligned stereo PCM")
-            target_frames = full_size // 4
+            def decode_full(name: str, *, untrimmed: bool) -> tuple[pathlib.Path, str]:
+                raw_path = workspace / name
+                # Measured after the resample, which is where librosa measures
+                # it, and before the s16 conversion, which would clamp the
+                # overshoot.
+                report = _decode(ffmpeg, [
+                    *(UNTRIMMED if untrimmed else ()),
+                    "-i", str(match_full), "-map", "0:a:0", "-vn",
+                    "-af", f"aresample={SAMPLE_RATE},{MEASURE}",
+                    "-ar", str(SAMPLE_RATE), "-ac", str(CHANNELS),
+                    "-f", "s16le", str(raw_path),
+                ], report=True)
+                size = raw_path.stat().st_size
+                if not size or size % 4:
+                    raise ValueError("full track decodes to empty or unaligned stereo PCM")
+                return raw_path, report
+
+            # The separator's grid, which its stem comes back on, and the deck's
+            # grid, which the sidecar is indexed against.
+            trimmed_raw, trimmed_report = decode_full("trimmed.s16le", untrimmed=False)
+            offset: int | None = None
+            try:
+                untrimmed_raw, untrimmed_report = decode_full("full.s16le", untrimmed=True)
+            except (RuntimeError, ValueError):
+                # An ffmpeg too old to know the flag, rather than a broken file:
+                # the same decode already succeeded without it.
+                untrimmed_raw = None
+            else:
+                offset = _encoder_delay(trimmed_raw, untrimmed_raw)
+            if offset is None:
+                # Staying on the separator's grid is what every release before
+                # this did, and it is right for a source declaring no padding.
+                aligned = False
+                full_raw, measured = trimmed_raw, trimmed_report
+                if untrimmed_raw is not None:
+                    untrimmed_raw.unlink()
+            else:
+                delay = offset
+                full_raw, measured = untrimmed_raw, untrimmed_report
+                trimmed_raw.unlink()
+            target_frames = full_raw.stat().st_size // 4
 
             peak = _peak_amplitude(measured)
             # An unreadable report leaves the stem alone: a wrong correction is
@@ -126,9 +213,12 @@ def write_sidecar(
         arguments = ["-i", str(vocals), "-map", "0:a:0", "-vn"]
         chain = [] if gain == 1.0 else [f"volume={gain:.9f}:precision=float"]
         if target_frames is not None:
-            chain.extend([
-                f"aresample={SAMPLE_RATE}", "apad", f"atrim=end_sample={target_frames}",
-            ])
+            chain.append(f"aresample={SAMPLE_RATE}")
+            # Silence for exactly the padding the deck's decoder will play
+            # before the first sample the separator ever saw.
+            if delay:
+                chain.append(f"adelay=delays={delay}S:all=1")
+            chain.extend(["apad", f"atrim=end_sample={target_frames}"])
             arguments.extend(["-ac", str(CHANNELS)])
         else:
             arguments.extend(["-ar", str(SAMPLE_RATE), "-ac", str(CHANNELS)])
@@ -167,4 +257,6 @@ def write_sidecar(
         payload_bytes=size,
         gain=gain,
         clipped=clipped,
+        delay=delay,
+        aligned=aligned,
     )


### PR DESCRIPTION
Two reasons a rx3stem was ignored or failed to cancel on the RX3.

Rekordbox truncates a filename to the first 44 characters of its stem when it exports a track to a drive, and leaves the library file alone. The hook asks for the sidecar under the basename it loaded, which is the truncated one, so a long title never matched. Sidecar names now go through the same cut, applied before the collision check so two titles differing only past character 44 are reported rather than overwritten.

mp3 and AAC declare the samples their encoder prepended. FFmpeg drops them, the deck plays them, and PcmReader position zero is the first sample its own decoder emits. A stem cut on FFmpeg's grid therefore sat about 25 ms early, which left the vocal fully audible in the instrumental while the vocal pad still worked. The encoder now decodes the source with and without -flags2 +skip_manual, locates the trimmed decode inside the untrimmed one to measure the padding exactly, and delays the stem by that before padding and trimming it to the untrimmed length. Sources declaring no padding are untouched. When the offset cannot be measured the stem stays on the separator's grid and the run reports it.

Verified on a padded and an unpadded 320 kb/s source: the padded one now cancels to 1 LSB against the deck's decode, the unpadded one is unchanged.