### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 # Changelog
 
-## Unreleased
+## 0.4.0
+
+Two reasons a sidecar was ignored or left the vocal in the instrumental. Both
+affect tracks prepared by any earlier version, which have to be generated again.
 
 ### Fixed
 


### PR DESCRIPTION
Closes the changelog section opened by #1 so the `v0.4.0` tag has release notes.

No code change: `CHANGELOG.md` only, `Unreleased` becomes `0.4.0` with a line
saying that sidecars prepared by an earlier version have to be generated again.

Merging this unblocks tagging `v0.4.0`, which is what triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)