### PR TITLE
fix(ci): run the mod generator tests under their current name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install release dependencies
         run: python -m pip install -r requirements-release.txt
       - name: Test the portable build engine
-        run: python -m unittest discover -s tests -p test_toolkit_builder.py
+        run: python -m unittest discover -s tests -p test_mod_generator.py
       - name: Build the desktop application
         env:
           RX3_PREBUILT_HOOK: ${{ github.workspace }}/prebuilt/librx3_stems.so


### PR DESCRIPTION
The `v0.4.0` release run built RX3 Stem Studio on all four platforms and failed
every Mod Generator job at *Test the portable build engine*:

```
Ran 0 tests in 0.000s
NO TESTS RAN
##[error]Process completed with exit code 1
```

`release.yml` still selected `tests/test_toolkit_builder.py`, which 0.3.0
renamed to `tests/test_mod_generator.py`. Since Python 3.12 an empty discovery
exits non-zero, so the four jobs died before building and `publish` was skipped.

This is why `v0.3.0` has no assets either — its run was blocked on billing, so
the broken reference never surfaced.

Locally: `python -m unittest discover -s tests -p test_mod_generator.py` → 7 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)