### PR TITLE
fix(runtime): write the module index with unix line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 # Changelog
 
+## 0.5.2
+
+A runtime built on Windows loads its modules again.
+
+### Fixed
+
+- An `autoexec.bin` built on Windows no longer stops with
+  `STOP: one or more runtime modules violate their contract`, preceded by one
+  `FAILED: unsafe runtime module directory` per selected module. The module
+  index the runtime reads to know what to load is written line by line from
+  Python, which translates each newline to the platform's own unless it is told
+  not to. On Windows that appended a carriage return to every line, and the
+  shell that reads the index takes it as the last character of the directory
+  name, so no module passed the name check. Affects 0.5.0 and 0.5.1; builds
+  made on Linux and macOS were never affected, and 0.4.0 predates the index.
+
 ## 0.5.1
 
 Reinserting the drive works. It used to be refused, and before that it was what

--- a/tests/test_mod_generator.py
+++ b/tests/test_mod_generator.py
@@ -111,10 +111,31 @@ class ModGeneratorTests(unittest.TestCase):
             )
             self.assertEqual(result.patches, ("core", "keyshift"))
             plain = load_firmware_codec().read_autoexec(result.output, key)
-            normalized = plain.replace(b"\r\n", b"\n")
 
-            self.assertIn(b"compatibility\ncore\nkeyshift\n", normalized)
-            self.assertNotIn(b"\nstems\n", normalized)
+            self.assertIn(b"compatibility\ncore\nkeyshift\n", plain)
+            self.assertNotIn(b"\nstems\n", plain)
+
+    def test_the_module_index_is_written_with_unix_line_endings(self):
+        """The index is read line by line by /bin/sh on the player, where a
+        trailing CR is part of the directory name and fails the module-name
+        check. Python translates \\n to os.linesep unless told not to, so a
+        build made on Windows shipped an index no module could be loaded from.
+        The source assertion carries the test on Linux and macOS, where that
+        translation never happens and the built image cannot show the fault."""
+        builder = (REPOSITORY / "tools/rx3_runtime/build.py").read_text()
+        self.assertRegex(
+            builder, r'modules / "index"\)\.write_text\((?s:.*?)newline=""'
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            directory = Path(directory)
+            key = directory / "aes256.key"
+            key.write_bytes(b"0123456789012345678901234567890\n")
+            result = build_runtime(
+                "1.19", ["keyshift"], key, directory, root=REPOSITORY
+            )
+            plain = load_firmware_codec().read_autoexec(result.output, key)
+            self.assertNotIn(b"compatibility\r", plain)
 
     def test_the_session_log_ships_only_when_its_module_is_selected(self):
         """say() runs before any module is loaded, so the orchestrator reads
@@ -133,14 +154,14 @@ class ModGeneratorTests(unittest.TestCase):
                 "1.19", ["keyshift"], key, directory, root=REPOSITORY
             )
             self.assertNotIn("logging", quiet.patches)
-            index = codec.read_autoexec(quiet.output, key).replace(b"\r\n", b"\n")
+            index = codec.read_autoexec(quiet.output, key)
             self.assertNotIn(b"\nlogging\n", index)
 
             verbose = build_runtime(
                 "1.19", ["keyshift", "logging"], key, directory, root=REPOSITORY
             )
             self.assertIn("logging", verbose.patches)
-            index = codec.read_autoexec(verbose.output, key).replace(b"\r\n", b"\n")
+            index = codec.read_autoexec(verbose.output, key)
             self.assertIn(b"\nlogging\n", index)
 
     def test_the_logging_module_warns_about_pulling_the_drive_out(self):

--- a/tools/rx3_runtime/build.py
+++ b/tools/rx3_runtime/build.py
@@ -485,7 +485,12 @@ def build_runtime(
                     notify("Compiling the performance core…")
                     compile_arm_hook(patch.directory / patch.arm_hook.source, target)
         module_index = ["compatibility"] + [patch.runtime_directory for patch in selected]
-        (modules / "index").write_text("".join(f"{item}\n" for item in module_index), encoding="ascii")
+        # newline="" keeps Python from translating these \n to os.linesep. The
+        # index is read by /bin/sh on the player, where a trailing CR is part of
+        # the directory name and fails the module-name check on every line.
+        (modules / "index").write_text(
+            "".join(f"{item}\n" for item in module_index), encoding="ascii", newline="",
+        )
         (staging / "autoexec.sh").chmod(0o755)
 
         notify("Creating and encrypting autoexec.bin…")


### PR DESCRIPTION
An `autoexec.bin` built on Windows stops with one `FAILED: unsafe runtime module directory` per selected module, then `STOP: one or more runtime modules violate their contract`. Nothing is applied, on every build, for every user on that platform.

Refs #11.

## Cause

The index naming the modules to load is written from Python, which translates each newline to the platform's own unless told otherwise. On Windows that appends a carriage return to every line.

`mod/autoexec.sh` reads the file with `IFS= read -r`, which strips the LF and keeps the CR, so the directory name reaching the check ends in a character it rejects — correctly, since that directory does not exist. Passing `newline=""` writes the LFs untranslated.

The bracketed names in the reported log break across two lines for the same reason: what sits before the `]` is a CR.

## Why the tests missed it

Two assertions normalised CRLF out of the built image before searching it — which is exactly what a build carrying this fault produces — so they passed on Windows rather than failing. They now assert the bytes as the player reads them.

The new regression test also asserts the `newline` argument in the source. Linux and macOS never perform the translation, so the built image cannot exhibit the fault there, and the unit tests only ever run on `ubuntu-24.04` in CI; a byte-level assertion alone would guard nothing.

## Scope

Affects 0.5.0 and 0.5.1. The module index arrived in `031e6ca`, so 0.4.0 predates it and is unaffected, which matches the report. Builds made on Linux and macOS were never affected.

## Checks

`make test` (134 tests) and `make preflight` pass locally.

## Note

Windows-built artifacts are not covered by CI: the packaging matrix builds on Windows but does not run `test_mod_generator` there. Worth a separate look.