### PR TITLE
Add Feature: Now Playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,55 @@ broken fax going up. Our brand new AI-generated pitch shifter algorithm is exact
 Beat Jump gets a new **32-beat** mode. Repeated presses also fire
 straight away instead of waiting for the grid to catch up.
 
+# Now Playing export
+
+Exposes the track loaded on each deck so a computer can display it — for OBS,
+VJ overlays, or track ID logging — while the RX3 plays standalone, with no
+rekordbox and no PRO DJ LINK.
+
+The code lives in the performance core's shared object; this module only decides
+whether it runs. It **patches nothing**: it rides the core's existing per-deck
+`track_did_load` dispatch, so selecting or dropping it never alters `rbp`'s
+executable words. Pull the stick and the player is stock.
+
+## What it does
+
+On every deck load the core hands the module the deck index and the loaded
+track's file path (the first field of `track_info`, the same datum the stems
+module reads). The module keeps the current path per deck and publishes both:
+
+* writes `/tmp/rx3-nowplaying.txt` on the device, and
+* UDP-broadcasts them on port **50123** to `255.255.255.255` and the APIPA
+  directed broadcast `169.254.255.255`, so a computer connected to the rear
+  computer USB type-B port (which exposes an Ethernet interface in the
+  `169.254.x.y` range) receives them without a telnet login.
+
+A 2-second beacon re-broadcasts the current state so a computer that connects
+after a track was loaded still catches up.
+
+## Wire format
+
+One UTF-8 datagram, newline-separated. A leading heartbeat line lets a listener
+confirm the module is alive before any track is loaded:
+
+    hb        RX3 nowplaying alive
+    0 <deck 1 file path>
+    1 <deck 2 file path>
+
+The file path is what the RX3 loaded (e.g. a rekordbox export path); a consumer
+typically derives artist/title from the basename.
+
+## Reading it on a computer
+
+Any UDP listener bound to port 50123 works. Allow inbound UDP 50123 through the
+computer's firewall.
+
+## Enabling
+
+Off by default. Select it in the app, or:
+
+    make autoexec KEY=/path/to/aes256.key MODULES="nowplaying"
+
 ### 🔌 Lives on the USB stick, not in the player
 
 Everything runs from the stick and disappears when the power goes off. Any RX3 you plug your stick on will be modded. Nothing

--- a/mod/modules/core/1.19/rx3_core_hook.c
+++ b/mod/modules/core/1.19/rx3_core_hook.c
@@ -322,7 +322,13 @@ static void keyshift_feature_track_did_load(unsigned int deck, void *reader,
 static const struct rx3_panel_feature keyshift_panel;
 static const struct rx3_panel_feature stems_panel;
 
-#define RUNTIME_FEATURE_COUNT 2u
+static int nowplaying_feature_configured(void);
+static int nowplaying_feature_install(void);
+static void nowplaying_feature_remove(void);
+static void nowplaying_feature_track_did_load(unsigned int deck, void *reader,
+                                              const void *track_info);
+
+#define RUNTIME_FEATURE_COUNT 3u
 
 static struct rx3_runtime_feature runtime_features[RUNTIME_FEATURE_COUNT] = {
     {
@@ -337,6 +343,12 @@ static struct rx3_runtime_feature runtime_features[RUNTIME_FEATURE_COUNT] = {
         stems_feature_configured, stems_feature_install,
         stems_feature_remove, stems_feature_track_will_load,
         stems_feature_track_did_load, 0, 0, stems_feature_destroy_deck
+    },
+    {
+        "nowplaying", 0, 0,
+        nowplaying_feature_configured, nowplaying_feature_install,
+        nowplaying_feature_remove, 0, nowplaying_feature_track_did_load,
+        0, 0, 0
     }
 };
 
@@ -1967,6 +1979,7 @@ static void apply_mix(struct stems_deck_context *context,
 /* Shared hook replacement. Feature-specific hooks are composed below. */
 #include "../../keyshift/1.19/rx3_keyshift_feature.h"
 #include "../../stems/1.19/rx3_stems_feature.h"
+#include "../../nowplaying/1.19/rx3_nowplaying_feature.h"
 
 static int hooked_load(void *reader, const void *track_info)
 {

--- a/mod/modules/nowplaying/1.19/manifest.json
+++ b/mod/modules/nowplaying/1.19/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "nowplaying",
+  "name": "Now Playing export",
+  "description": "Writes each deck's loaded track path to /tmp/rx3-nowplaying.txt for a computer to read over the USB-Ethernet link.",
+  "firmware": "1.19",
+  "default": false,
+  "order": 45,
+  "runtime_directory": "nowplaying",
+  "namespace": "nowplaying",
+  "requires": ["core"],
+  "conflicts": [],
+  "files": [
+    { "source": "module.sh", "target": "module.sh", "executable": false }
+  ],
+  "build_files": [
+    "rx3_nowplaying_feature.h"
+  ]
+}

--- a/mod/modules/nowplaying/1.19/module.sh
+++ b/mod/modules/nowplaying/1.19/module.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-License-Identifier: MPL-2.0
+# Now Playing export. The code lives in the performance core's shared object;
+# this module only decides whether it runs.
+
+module_begin nowplaying nowplaying
+
+NOWPLAYING_READY=0
+
+nowplaying_prepare()
+{
+    [ -r "$CORE_OBJECT" ] || {
+        say "Now Playing disabled: the performance core is not selected"
+        return 1
+    }
+    export RX3_NOWPLAYING=1
+    NOWPLAYING_READY=1
+    running=$(rbp_environment_value RX3_NOWPLAYING)
+    if [ "$running" != "1" ]; then
+        say "Now Playing needs a restart: running rbp carries RX3_NOWPLAYING=[${running:-none}]"
+        request_rbp_restart
+    fi
+    say "Now Playing prepared: exporting /tmp/rx3-nowplaying.txt on each load"
+}
+
+nowplaying_after_launch()
+{
+    [ "$NOWPLAYING_READY" = "1" ] || return 0
+    say "Now Playing active: per-deck track path in /tmp/rx3-nowplaying.txt"
+}
+
+register_prepare_hook nowplaying_prepare
+register_after_launch_hook nowplaying_after_launch

--- a/mod/modules/nowplaying/1.19/rx3_nowplaying_feature.h
+++ b/mod/modules/nowplaying/1.19/rx3_nowplaying_feature.h
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: MPL-2.0 - now playing (final) */
+#ifndef RX3_NOWPLAYING_FEATURE_H
+#define RX3_NOWPLAYING_FEATURE_H
+
+extern int  socket(int, int, int);
+extern int  setsockopt(int, int, int, const void *, unsigned int);
+extern long sendto(int, const void *, size_t, int, const void *, unsigned int);
+
+#define NOWPLAYING_FILE      "/tmp/rx3-nowplaying.txt"
+#define NOWPLAYING_PATH_MAX  512u
+#define NP_ADDR_LIMITED  0xFFFFFFFFu
+#define NP_ADDR_APIPA    0xFFFFFEA9u
+
+struct np_sa { unsigned short f; unsigned short p; unsigned int a; unsigned char z[8]; };
+static char nowplaying_paths[2][NOWPLAYING_PATH_MAX];
+static int np_fd = -1;
+
+static void np_send(unsigned int addr, const char *b, unsigned int n)
+{
+    if (np_fd < 0) {
+        int fd = socket(2, 2, 0);
+        if (fd < 0) return;
+        int on = 1;
+        (void)setsockopt(fd, 1, 6, &on, sizeof(on));
+        np_fd = fd;
+    }
+    struct np_sa d;
+    memset(&d, 0, sizeof(d));
+    d.f = 2;
+    d.p = (unsigned short)((50123u >> 8) | (50123u << 8));
+    d.a = addr;
+    (void)sendto(np_fd, b, n, 0, &d, sizeof(d));
+}
+
+static void nowplaying_broadcast(void)
+{
+    char buf[2u * (NOWPLAYING_PATH_MAX + 8u) + 32u];
+    unsigned int n = 0u;
+    const char *hb = "hb\tRX3 nowplaying alive\n";
+    for (const char *h = hb; *h; ) buf[n++] = *h++;
+    for (unsigned int deck = 0; deck < 2u; deck++) {
+        const char *p = nowplaying_paths[deck];
+        buf[n++] = (char)('0' + deck);
+        buf[n++] = '\t';
+        while (*p && n < sizeof(buf) - 2u) buf[n++] = *p++;
+        buf[n++] = '\n';
+    }
+    np_send(NP_ADDR_LIMITED, buf, n);
+    np_send(NP_ADDR_APIPA, buf, n);
+    int fd = open(NOWPLAYING_FILE, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) { (void)write(fd, buf, n); (void)close(fd); }
+}
+
+static void *nowplaying_beacon(void *arg)
+{
+    (void)arg;
+    for (;;) { nowplaying_broadcast(); usleep(2000000u); }
+    return 0;
+}
+
+static int nowplaying_feature_configured(void) { return getenv("RX3_NOWPLAYING") != 0; }
+static int nowplaying_feature_install(void)
+{
+    pthread_t t;
+    if (pthread_create(&t, 0, nowplaying_beacon, 0) == 0) pthread_detach(t);
+    return 1;
+}
+static void nowplaying_feature_remove(void) {}
+
+static void nowplaying_feature_track_did_load(unsigned int deck, void *reader,
+                                              const void *track_info)
+{
+    (void)reader;
+    if (deck >= 2u) return;
+    const char *path = (const char *)track_info;
+    unsigned int i = 0u;
+    if (path) {
+        while (path[i] && i < NOWPLAYING_PATH_MAX - 1u) {
+            nowplaying_paths[deck][i] = path[i];
+            i++;
+        }
+    }
+    nowplaying_paths[deck][i] = '\0';
+    nowplaying_broadcast();
+    log_line("nowplaying: track loaded");
+}
+
+#endif /* RX3_NOWPLAYING_FEATURE_H */

--- a/test-regressions.py
+++ b/test-regressions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+"""Static guards for the now playing module, all of them measured facts."""
+
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parent
+MODULE = (ROOT / "module.sh").read_text()
+FEATURE = (ROOT / "rx3_nowplaying_feature.h").read_text()
+MANIFEST = json.loads((ROOT / "manifest.json").read_text())
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+require(
+    "register_prepare_hook nowplaying_prepare" in MODULE
+    and "export RX3_NOWPLAYING=1" in MODULE,
+    "the module must announce itself to the core through the environment",
+)
+require(
+    '[ -r "$CORE_OBJECT" ]' in MODULE,
+    "the module must decline when the performance core is not selected",
+)
+require(
+    "register_patch" not in MODULE,
+    "now playing rides the core dispatch and must not patch any word",
+)
+require(
+    MANIFEST["requires"] == ["core"]
+    and "rx3_nowplaying_feature.h" in MANIFEST["build_files"],
+    "now playing must declare its core dependency and own its header",
+)
+require(
+    MANIFEST["default"] is False and MANIFEST["namespace"] == "nowplaying",
+    "now playing is opt-in and owns the nowplaying namespace",
+)
+require(
+    'getenv("RX3_NOWPLAYING")' in FEATURE
+    and "nowplaying_feature_track_did_load" in FEATURE,
+    "the feature must gate on its environment flag and take the load hook",
+)
+require(
+    "(const char *)track_info" in FEATURE,
+    "the feature reads the loaded path from track_info, like stems",
+)
+require(
+    "sendto" in FEATURE and "50123" in FEATURE,
+    "the feature exports over UDP on the documented port",
+)
+
+print("Now playing regression guards: OK")


### PR DESCRIPTION
# Now Playing export

Exposes the track loaded on each deck so a computer can display it — for OBS, VJ overlays, or track ID logging — while the RX3 plays standalone, with no rekordbox and no PRO DJ LINK.

Tested with my own semi-VJ page.